### PR TITLE
fix: use console.warn in LSP warn

### DIFF
--- a/server/src/utils/lsp-console.ts
+++ b/server/src/utils/lsp-console.ts
@@ -51,7 +51,7 @@ export const info = ( value: string ) => {
 /** @description value could be an error */
 export const warn = ( value: unknown ) => {
   if(process.env.VSCODE_DEBUG_MODE) {
-    console.error(stringifyUnknown(value));
+    console.warn(stringifyUnknown(value));
   }
 
   lspConsole.console?.warn(stringifyUnknown(value, true));


### PR DESCRIPTION
## Summary
- correct debug logging in warn to use console.warn

## Testing
- `npm test` *(fails: Cannot find module '/workspace/varsu/client/out/test/runTest')*

------
https://chatgpt.com/codex/tasks/task_e_688f2679c884832698b8cd3d4893576d